### PR TITLE
Added ability to type hint a task

### DIFF
--- a/src/League/Grunt/Console.php
+++ b/src/League/Grunt/Console.php
@@ -180,7 +180,9 @@ class Console
                 if ($taskFunction instanceof \Closure) {
                     $taskInformation = \ReflectionFunction::export($gruntHolder['tasks'][$taskName], TRUE);
 
-                    if (strpos($taskInformation, '<required> $g') !== FALSE) {
+                    if (strpos($taskInformation, '<required> $g') !== FALSE ||
+                        strpos($taskInformation, '<required> League\Grunt\Grunt $g') !== FALSE
+                    ) {
                         self::setTask($taskName, new \ReflectionFunction($taskFunction));
                     }
                 }


### PR DESCRIPTION
Added ability to type hint a Grunt task so that syntax like:

``` php
<?php

use League\Grunt\Grunt;

return [
    'hosts' => [
        'production' => 'foo.com'
    ],
    'tasks' => [
        'deploy' => function(Grunt $g) {
            $g->run('ls');
        }
    ],
];
```

Can be used. This gives the ability to autocomplete methods from an IDE, as well as aid in using debuggers.
