### PR TITLE
Add result handler to run command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+.project
+.buildpath
 phpunit.xml
 composer.lock
 /vendor
+/.settings

--- a/src/League/Shunt/Contracts/ShuntInterface.php
+++ b/src/League/Shunt/Contracts/ShuntInterface.php
@@ -114,11 +114,12 @@ interface ShuntInterface
     /**
      * Shunt runner
      *
-     * @param  string $command Command to execute
-     * @param  bool   $retval  Return value
-     * @return mixed  $retval or null
+     * @param  string   $command       Command to execute
+     * @param  bool     $retval        Return value
+     * @param  callable $resultHandler Callback to handle the command's result
+     * @return mixed    $retval        or null
      */
-    public function run($command, $retval = FALSE);
+    public function run($command, $retval = FALSE, callable $resultHandler = null);
 
     /**
      * Register error handler

--- a/src/League/Shunt/Shunt.php
+++ b/src/League/Shunt/Shunt.php
@@ -169,7 +169,7 @@ class Shunt extends BaseObject implements ShuntInterface
     /**
      * @{inheritDoc}
      */
-    public function run($command, $retval = FALSE)
+    public function run($command, $retval = FALSE, callable $resultHandler = null)
     {
         $this->addCommand($command);
 
@@ -225,6 +225,11 @@ class Shunt extends BaseObject implements ShuntInterface
             } else {
                 $this->printOut('<comment>'.$host.'</comment> > <info>'.$resultDio.'</info>');
             }
+        }
+
+        // invoke the result handler if we've a result indeed
+        if ($resultHandler && $resultDio) {
+            call_user_func_array($resultHandler, array($resultDio));
         }
 
         if ($retval) return (int) $halt;


### PR DESCRIPTION
Hi,

first i want to say, thanks for that awesome piece of code :+1: 

We've the requirement, that we want to execute a remote command by invoking the `run()` method and need to have access to the result.

```php
<?php

return array(

    'hosts' => array(
        'jenkins' => '127.0.0.1',
    ),

    'auth' => array(
        'username' => 'root',
        'password' => NULL,
        'pubkeyfile' => '/home/user/.ssh/id_rsa.pub',
        'privkeyfile' => '/home/user/.ssh/id_rsa',
        'passphrase' => NULL,
    ),

    'tasks' => array(
        'download_test' => function($s) {

            $local = '';
            if (is_file('/tmp/test_encoded.php')) {
                $local = md5_file('/tmp/test_encoded.php');
            }
            
            $remote = '';
            $resultHandler = function ($resultDio) use (&$remote) {
                $result = explode('  ', $resultDio);
                $remote = array_shift($result);
            };
            
            $s->run('md5sum test_encoded.php', false, $resultHandler);
            
            if ($local === $remote) {
                error_log(sprintf('Hashes ARE equal %s/%s', $local, $remote));
            } else {
                error_log(sprintf('Hashes are NOT equal %s/%s', $local, $remote));
                $s->scp()->get('test_encoded.php', '/tmp/test_encoded.php');
            }
        }
    ),
);
```

The pull request added a third parameter that allows you to specify a closure that can be used to access the command's result. Actually i think there is no possibility to do this, right?